### PR TITLE
Add environment.yaml

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,12 @@
+name: snakemake-tutorial
+channels: 
+  - conda-forge
+  - bioconda
+dependencies: 
+  - pip
+  - snakemake
+  - pandas 
+  - seaborn
+  - matplotlib
+  - pip:
+    - sciencebasepy


### PR DESCRIPTION
Add an environment.yaml file for easy installation of `snakemake` and other dependencies using `conda`. Fixes #4.

Create a new conda environment by running
```
conda update -n base conda
conda env create -f environment.yaml
conda activate snakemake-tutorial
```

- I named the environment `snakemake-tutorial`. A bit wordy, but descriptive.

- In the README, we might want to remind folks to disconnect from VPN before creating the environment, since `pip` doesn't work well when connected.