### PR TITLE
Add rule all to Snakefile

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,3 +1,7 @@
+rule all:
+    input:
+        "3_plot/out/doy_plot.png"
+
 """
 Download data from ScienceBase
 """


### PR DESCRIPTION
Add a rule named `all` at the top of the Snakefile. Because it's the first rule in the Snakefile, `snakemake` calls this rule by default if no file or rule is specified at the command line. In other words,
```
snakemake -c1
```
will trigger rule `all`.