### PR TITLE
add cloning instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # snakemake-tutorial-scratch
+This repository was built to be used as an introductory tutorial for using Snakemake as a pipelining tool for Python code. It introduces some general Snakemake concepts and gives an opportunity to practice implementing them on a small example problem.
+
+The tutorial is broken up into an ordered set of lessons, each of which introduces a new Snakemake concept (or sometimes two). Each lesson is contained in a markdown file in the `issue_drafts` folder of this repository. The rest of the code contained in the repository is the codebase you will start from and modify as you go through each lesson.
+
+In order to walk through this tutorial, you should clone this repository onto your local computer, and open up the markdown file `issue_drafts/issue_0.md`, which takes you through some basic computer setup. You can then proceed through the following issue drafts to continue through the tutorial.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ The tutorial is broken up into an ordered set of lessons, each of which introduc
 In order to walk through this tutorial, you should make a fork of this repository onto your own Github. Then you can clone your fork of this repository onto your local computer to work on.
 
 To begin the tutorial, open up the markdown file `issue_drafts/issue_0.md`, which takes you through some basic computer setup. You can then proceed through the following issue drafts to continue through the tutorial.
+
+For every issue (except issue 0), you will be making changes to the code in the repository. If you are working with an instructor for this tutorial, you should push your changes from you local repository to your remote repository at the after finishing each issue. You can then open a pull request on your fork of the repository with your code changes, and request review by your instructor. After they approve the pull request, make sure to pull down and changes from Github to your local copy of the repository, and continue on with the next issue.

--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@ This repository was built to be used as an introductory tutorial for using Snake
 
 The tutorial is broken up into an ordered set of lessons, each of which introduces a new Snakemake concept (or sometimes two). Each lesson is contained in a markdown file in the `issue_drafts` folder of this repository. The rest of the code contained in the repository is the codebase you will start from and modify as you go through each lesson.
 
-In order to walk through this tutorial, you should clone this repository onto your local computer, and open up the markdown file `issue_drafts/issue_0.md`, which takes you through some basic computer setup. You can then proceed through the following issue drafts to continue through the tutorial.
+In order to walk through this tutorial, you should make a fork of this repository onto your own Github. Then you can clone your fork of this repository onto your local computer to work on.
+
+To begin the tutorial, open up the markdown file `issue_drafts/issue_0.md`, which takes you through some basic computer setup. You can then proceed through the following issue drafts to continue through the tutorial.


### PR DESCRIPTION
Adding some basic instructions to clone the repo and get started. I kept it pretty basic, so feel free to add more flare if you'd like. I mostly just wanted to get something up to hand over to David.

Once we merge these instructions, I think we need to:
- copy over the readme and issue_drafts to snakemake-introduction (the real starting point, this is just the answer key - in fact, maybe we should delete them from here so we only have one copy to maintain)
- ask David to test out the lesson, given the snakemake-introduction repository
- figure out if we want to convert the md files into issues, and update the instructions if we do